### PR TITLE
:construction_worker: ci: deploy to Pages using Actions

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,7 +1,7 @@
 name: Docs
 on: [push, pull_request, workflow_dispatch]
-jobs:
-  docs:
+jobs:        
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -12,11 +12,26 @@ jobs:
       - name: Sphinx build
         run: |
           make html
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      - name: Publish artifact
+        uses: actions/upload-pages-artifact@v1.0.7
         with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/
-          force_orphan: true
+          path: _build/
+
+  deploy:
+    needs: build
+
+    # We need a GitHub Token with write access on Pages
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      # Note: This Actions publishes the artifact created in 'build' step to Pages
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
GitHub's default is now to use Actions to deploy to Pages and they seems to slowly deprecate features on the old branch-based deployment so moving forward, repos should use Actions to deploy to Pages

Note: Workflow was tested (https://github.com/Aeris1One/Documentation/actions/runs/4242248120). It needs the "Deploy with Actions" option to be enabled on the repository and the branch to be authorized in repo settings (if the branch isn't authorized, only the build step will take place to ensure the docs can be built but they will not be deployed to Pages)